### PR TITLE
fix(React+Typescript+vanilla): Add missing closing double quote to manifest.lkml.template

### DIFF
--- a/templates/react-javascript/manifest.lkml.template
+++ b/templates/react-javascript/manifest.lkml.template
@@ -18,7 +18,7 @@ project_name: "${options.projectName}"
 application: ${options.projectName} {
   label: "${options.projectName}"
   url: "https://localhost:8080/bundle.js"
-  # file: "bundle.js
+  # file: "bundle.js"
   entitlements: {
     core_api_methods: ["me"] #Add more entitlements here as you develop new functionality
   }

--- a/templates/react-typescript/manifest.lkml.template
+++ b/templates/react-typescript/manifest.lkml.template
@@ -18,7 +18,7 @@ project_name: "${options.projectName}"
 application: ${options.projectName} {
   label: "${options.projectName}"
   url: "https://localhost:8080/bundle.js"
-  # file: "bundle.js
+  # file: "bundle.js"
   entitlements: {
     core_api_methods: ["me"] #Add more entitlements here as you develop new functionality
   }

--- a/templates/vanilla-javascript/manifest.lkml.template
+++ b/templates/vanilla-javascript/manifest.lkml.template
@@ -18,7 +18,7 @@ project_name: "${options.projectName}"
 application: ${options.projectName} {
   label: "${options.projectName}"
   url: "https://localhost:8080/bundle.js"
-  # file: "bundle.js
+  # file: "bundle.js"
   entitlements: {
     core_api_methods: ["me"] #Add more entitlements here as you develop new functionality
   }

--- a/templates/vanilla-typescript/manifest.lkml.template
+++ b/templates/vanilla-typescript/manifest.lkml.template
@@ -18,7 +18,7 @@ project_name: "${options.projectName}"
 application: ${options.projectName} {
   label: "${options.projectName}"
   url: "https://localhost:8080/bundle.js"
-  # file: "bundle.js
+  # file: "bundle.js"
   entitlements: {
     core_api_methods: ["me"] #Add more entitlements here as you develop new functionality
   }


### PR DESCRIPTION
Fixes #22 